### PR TITLE
Run validate on form start.

### DIFF
--- a/src/DefaultStateProvider.js
+++ b/src/DefaultStateProvider.js
@@ -464,6 +464,8 @@ class DefaultStateProvider<T> extends React.PureComponent<Props<T>, State> {
     super(props);
     this._willUnmount = false;
     this.state = this.getInitialState();
+    Object.assign(this.state, runWarn(this.state, this.props));
+    Object.assign(this.state, runValidate(this.state, this.props));
   }
 
   render() {

--- a/src/Field.js
+++ b/src/Field.js
@@ -136,7 +136,7 @@ class FieldWrapper extends React.PureComponent<FieldWrapperProps> {
       Object.assign(
         {
           // Input Tag Props
-          props,
+          input: props,
           composeProps,
 
           // "Meta" Props
@@ -229,7 +229,7 @@ Field.defaultProps = {
   parse: (v: mixed) => v,
   checkbox: false,
   validateOnBlur: true,
-  validateOnChange: false,
+  validateOnChange: true,
 };
 
 export default Field;

--- a/src/Form.js
+++ b/src/Form.js
@@ -69,7 +69,7 @@ class Form<StateProviderProps>
             submitFailed={context.submitFailed}
             submitSucceeded={context.submitSucceeded}
             hasErrors={
-              context.errorState !== null && context.submitErrorState !== null
+              context.errorState !== null || context.submitErrorState !== null
             }
             hasWarnings={context.warningState !== null}
           >


### PR DESCRIPTION
There is probably a better way to do this, especially since who knows if `Object.assign` is polyfilled correctly. But the idea here is important. The form should have `hasErrors` set to true initially to disable the submit button until all fields are valid. 

Since the error state was not caused by the user its visibility can be controlled by `touched && error`. 

My assumption is that the form can still be submitted with warnings, although I don't know the difference between the two. Is there an acknowledgement step for warnings? Or is it purely just an informational chunk of state you can use to show additional information based on user input?

Anyway, feel free to close this if you have a proper mechanism.

Also:

```js
hasErrors={
  context.errorState !== null && context.submitErrorState !== null
}
```

It would be good to be able to differentiate the two. Disabling the submit button is good ONLY when `context.errorState !== null` since `submitErrorState` is entirely server controlled. My assumption is that the above logic is also supposed to be:

```js
context.errorState !== null || context.submitErrorState !== null
```