### PR TITLE
Update validation logic

### DIFF
--- a/src/DefaultStateProvider.js
+++ b/src/DefaultStateProvider.js
@@ -23,24 +23,8 @@ import SubmitValidationError from './SubmitValidationError';
 type Props<T> = DefaultStateProviderProps<T>;
 type State = Context;
 
-const safeSet = (state: Context, path: PathArray, value: mixed) => {
-  let nextState = state;
-
-  const baseIsNull = nextState[path[0]] === null;
-
-  const tempState = baseIsNull ? set(nextState, [path[0]], {}) : nextState;
-
-  nextState = set(tempState, path, value);
-
-  if (nextState === tempState) {
-    return state;
-  }
-
-  return nextState;
-};
-
 const updateWarningState = (state: State) => {
-  let nextState = state;
+  let nextState: State = state;
 
   if (!hasValue(nextState.warningState)) {
     nextState = set(nextState, ['warningState'], null);
@@ -50,7 +34,7 @@ const updateWarningState = (state: State) => {
 };
 
 const updateErrorState = (state: State) => {
-  let nextState = state;
+  let nextState: State = state;
 
   if (!hasValue(nextState.errorState)) {
     nextState = set(nextState, ['errorState'], null);
@@ -60,7 +44,7 @@ const updateErrorState = (state: State) => {
 };
 
 const updateSubmitErrorState = (state: State) => {
-  let nextState = state;
+  let nextState: State = state;
 
   if (!hasValue(nextState.submitErrorState)) {
     nextState = set(nextState, ['submitErrorState'], null);
@@ -69,50 +53,62 @@ const updateSubmitErrorState = (state: State) => {
   return nextState;
 };
 
-const updateValue = (path: PathArray, value: mixed) => (state: State) => {
-  if (path.length < 1) {
-    throw new TypeError(emptyPathArrayError());
+const runWarn = <T>(state: State, props: Props<T>) => {
+  let nextState: State = state;
+
+  const warningState = props.warn(state.valueState) || null;
+
+  nextState = set(nextState, ['warningState'], warningState);
+
+  if (nextState.warningState !== state.warningState) {
+    nextState = updateWarningState(nextState);
   }
-
-  let nextState = state;
-
-  nextState = set(nextState, ['valueState'].concat(path), value);
 
   if (nextState === state) {
     return null;
   }
 
-  nextState = set(nextState, ['warningStale'], true);
-  nextState = set(nextState, ['validationStale'], true);
+  return nextState;
+};
 
-  // Clear warning state at path.
-  if (nextState.warningState !== null) {
-    nextState = set(nextState, ['warningState'].concat(path), undefined);
+const runValidate = <T>(state: State, props: Props<T>) => {
+  let nextState: State = state;
 
-    if (nextState.warningState !== state.warningState) {
-      nextState = updateWarningState(nextState);
-    }
+  const errorState = props.validate(state.valueState) || null;
+
+  nextState = set(nextState, ['errorState'], errorState);
+
+  if (nextState.errorState !== state.errorState) {
+    nextState = updateErrorState(nextState);
   }
 
-  // Clear error state at path.
-  if (nextState.errorState !== null) {
-    nextState = set(nextState, ['errorState'].concat(path), undefined);
-
-    if (nextState.errorState !== state.errorState) {
-      nextState = updateErrorState(nextState);
-    }
-  }
-
-  // Clear submit error state at path.
-  if (nextState.submitErrorState !== null) {
-    nextState = set(nextState, ['submitErrorState'].concat(path), undefined);
-
-    if (nextState.submitErrorState !== state.submitErrorState) {
-      nextState = updateSubmitErrorState(nextState);
-    }
+  if (nextState === state) {
+    return null;
   }
 
   return nextState;
+};
+
+const updateValue = (path: PathArray, value: mixed) => {
+  return function<T>(state: State, props: Props<T>) {
+    if (path.length < 1) {
+      throw new TypeError(emptyPathArrayError());
+    }
+
+    let nextState: State = state;
+
+    nextState = set(nextState, ['valueState'].concat(path), value);
+
+    if (nextState === state) {
+      return null;
+    }
+
+    nextState = runWarn(nextState, props) || nextState;
+    nextState = runValidate(nextState, props) || nextState;
+    nextState = set(nextState, ['submitErrorState'], null);
+
+    return nextState;
+  };
 };
 
 const updateInitialValue = (path: PathArray, value: mixed) => (
@@ -122,7 +118,7 @@ const updateInitialValue = (path: PathArray, value: mixed) => (
     throw new TypeError(emptyPathArrayError());
   }
 
-  let nextState = state;
+  let nextState: State = state;
 
   nextState = set(nextState, ['initialValueState'].concat(path), value);
 
@@ -140,57 +136,9 @@ const updatePendingValue = (path: PathArray, value: mixed) => (
     throw new TypeError(emptyPathArrayError());
   }
 
-  let nextState = state;
+  let nextState: State = state;
 
   nextState = set(nextState, ['pendingValueState'].concat(path), value);
-
-  if (nextState === state) {
-    return null;
-  }
-
-  return nextState;
-};
-
-const updateWarning = (path: PathArray, warning: mixed) => (state: State) => {
-  if (path.length < 1) {
-    throw new TypeError(emptyPathArrayError());
-  }
-
-  let nextState = state;
-
-  nextState = safeSet(nextState, ['warningState'].concat(path), warning);
-
-  if (nextState === state) {
-    return null;
-  }
-
-  nextState = set(nextState, ['warningStale'], true);
-  nextState = updateWarningState(nextState);
-
-  return nextState;
-};
-
-const updateError = (path: PathArray, error: mixed) => (state: State) => {
-  if (path.length < 1) {
-    throw new TypeError(emptyPathArrayError());
-  }
-
-  let nextState = state;
-
-  nextState = safeSet(nextState, ['errorState'].concat(path), error);
-
-  if (nextState !== state) {
-    nextState = set(nextState, ['validationStale'], true);
-    nextState = updateErrorState(nextState);
-  }
-
-  const reference = nextState;
-
-  nextState = safeSet(nextState, ['submitErrorState'].concat(path), undefined);
-
-  if (nextState !== reference) {
-    nextState = updateSubmitErrorState(nextState);
-  }
 
   if (nextState === state) {
     return null;
@@ -204,7 +152,7 @@ const updateVisited = (key: string, visited: boolean) => (state: State) => {
     throw new TypeError(emptyPathStringError());
   }
 
-  let nextState = state;
+  let nextState: State = state;
 
   const updater = (currentVisited) => {
     return !!currentVisited === visited ? currentVisited : visited;
@@ -223,8 +171,7 @@ const updateTouched = (key: string, touched: boolean) => (state: State) => {
   if (key.length < 1) {
     throw new TypeError(emptyPathStringError());
   }
-
-  let nextState = state;
+  let nextState: State = state;
 
   const updater = (currentTouched) => {
     return !!currentTouched === touched ? currentTouched : touched;
@@ -259,50 +206,8 @@ const updateFocused = (key: string, focused: boolean) => (state: State) => {
   return {focusedPath: null};
 };
 
-const runWarn = <T>(state: State, props: Props<T>) => {
-  let nextState = state;
-
-  if (state.warningStale) {
-    const warningState = props.warn(state.valueState) || null;
-
-    nextState = set(nextState, ['warningStale'], false);
-    nextState = set(nextState, ['warningState'], warningState);
-  }
-
-  if (nextState.warningState !== state.warningState) {
-    nextState = updateWarningState(nextState);
-  }
-
-  if (nextState === state) {
-    return null;
-  }
-
-  return nextState;
-};
-
-const runValidate = <T>(state: State, props: Props<T>) => {
-  let nextState = state;
-
-  if (state.validationStale) {
-    const errorState = props.validate(state.valueState) || null;
-
-    nextState = set(nextState, ['validationStale'], false);
-    nextState = set(nextState, ['errorState'], errorState);
-  }
-
-  if (nextState.errorState !== state.errorState) {
-    nextState = updateErrorState(nextState);
-  }
-
-  if (nextState === state) {
-    return null;
-  }
-
-  return nextState;
-};
-
 const updateSubmit = (error?: Error) => (state: State) => {
-  let nextState = state;
+  let nextState: State = state;
 
   nextState = set(nextState, ['submitting'], false);
   nextState = set(nextState, ['submitSucceeded'], !error);
@@ -340,14 +245,6 @@ class DefaultStateProvider<T> extends React.PureComponent<Props<T>, State> {
     this.setState(updatePendingValue(parsePath(path), value));
   }
 
-  setWarning(path: Path, error: mixed) {
-    this.setState(updateWarning(parsePath(path), error));
-  }
-
-  setError(path: Path, error: mixed) {
-    this.setState(updateError(parsePath(path), error));
-  }
-
   setVisited(path: Path, visited: boolean) {
     this.setState(updateVisited(formatPath(path), visited));
   }
@@ -358,11 +255,6 @@ class DefaultStateProvider<T> extends React.PureComponent<Props<T>, State> {
 
   setFocused(path: Path, focused: boolean) {
     this.setState(updateFocused(formatPath(path), focused));
-  }
-
-  validate() {
-    this.setState(runWarn);
-    this.setState(runValidate);
   }
 
   submit(event?: Event | SyntheticEvent<>) {
@@ -379,34 +271,21 @@ class DefaultStateProvider<T> extends React.PureComponent<Props<T>, State> {
       );
 
     setState((state, props) => {
-      let nextState = state;
-
-      if (nextState.submitting) {
+      if (state.submitting) {
         promise = Promise.reject(
           new Error('Form submit blocked pending current submit resolution.'),
         );
         return null;
       }
 
-      nextState = runValidate(nextState, props) || nextState;
-
-      if (nextState.errorState !== null) {
-        promise = Promise.reject(
-          new SubmitValidationError(nextState.errorState),
-        );
-
-        if (nextState === state) {
-          return null;
-        }
-
-        return nextState;
+      if (state.errorState !== null) {
+        promise = Promise.reject(new SubmitValidationError(state.errorState));
+        return null;
       }
 
-      nextState = set(nextState, ['submitting'], true);
+      promise = Promise.resolve(state.valueState).then(props.onSubmit);
 
-      promise = Promise.resolve(nextState.valueState).then(props.onSubmit);
-
-      return nextState;
+      return set(state, ['submitting'], true);
     }).then(() => {
       promise.then(
         (result) =>
@@ -438,19 +317,14 @@ class DefaultStateProvider<T> extends React.PureComponent<Props<T>, State> {
       submitting: false,
       submitFailed: false,
       submitSucceeded: false,
-      warningStale: true,
-      validationStale: true,
 
       actions: {
         setValue: this.setValue.bind(this),
         setInitialValue: this.setInitialValue.bind(this),
         setPendingValue: this.setPendingValue.bind(this),
-        setWarning: this.setError.bind(this),
-        setError: this.setError.bind(this),
         setTouched: this.setTouched.bind(this),
         setVisited: this.setVisited.bind(this),
         setFocused: this.setFocused.bind(this),
-        validate: this.validate.bind(this),
         submit: this.submit.bind(this),
       },
     };
@@ -491,7 +365,7 @@ DefaultStateProvider.getDerivedStateFromProps = <T>(
   props: Props<T>,
   state: State,
 ) => {
-  let nextState = state;
+  let nextState: State = state;
 
   nextState = set(nextState, ['pendingValueState'], props.values);
 

--- a/src/Field.js
+++ b/src/Field.js
@@ -33,6 +33,7 @@ class FieldWrapper extends React.PureComponent<FieldWrapperProps> {
       value,
       pendingValue,
       error,
+      submitError,
       warning,
       focused,
       touched,
@@ -65,6 +66,7 @@ class FieldWrapper extends React.PureComponent<FieldWrapperProps> {
     const dirty = value !== initialValue;
     const detached = value !== pendingValue;
     const hasError = hasValue(error);
+    const hasSubmitError = hasValue(submitError);
     const hasWarning = hasValue(warning);
 
     const focus = (focused: boolean) => setFocused(formattedPath, focused);
@@ -132,6 +134,8 @@ class FieldWrapper extends React.PureComponent<FieldWrapperProps> {
           // "Meta" Props
           hasError,
           error,
+          hasSubmitError,
+          submitError,
           hasWarning,
           warning,
           focused,

--- a/src/Field.js
+++ b/src/Field.js
@@ -27,8 +27,6 @@ class FieldWrapper extends React.PureComponent<FieldWrapperProps> {
       format,
       parse,
       checkbox,
-      validateOnBlur,
-      validateOnChange,
 
       // Field state
       initialValue,
@@ -48,7 +46,6 @@ class FieldWrapper extends React.PureComponent<FieldWrapperProps> {
       setValue,
       setInitialValue,
       setPendingValue,
-      validate,
       submit,
 
       // FieldArray Props
@@ -76,15 +73,11 @@ class FieldWrapper extends React.PureComponent<FieldWrapperProps> {
     const change = (nextValue) => {
       const parsedValue = parse(nextValue, value);
 
-      setValue(parsedPath, parsedValue);
-
       if (!detached) {
         setPendingValue(parsedPath, parsedValue);
       }
 
-      if (validateOnChange) {
-        validate();
-      }
+      setValue(parsedPath, parsedValue);
     };
 
     const input = {
@@ -97,9 +90,6 @@ class FieldWrapper extends React.PureComponent<FieldWrapperProps> {
       },
       onBlur() {
         focus(false);
-        if (validateOnBlur) {
-          validate();
-        }
         touch(true);
       },
       onChange(eventOrValue) {
@@ -168,7 +158,6 @@ class FieldWrapper extends React.PureComponent<FieldWrapperProps> {
             setPendingValue(parsedPath, value);
             setInitialValue(parsedPath, pendingValue);
           },
-          validate,
           submit,
 
           addFieldBefore: undefined,
@@ -185,15 +174,7 @@ class Field extends React.PureComponent<FieldProps> {
   static defaultProps: typeof Field.defaultProps;
 
   render() {
-    const {
-      path,
-      format,
-      parse,
-      checkbox,
-      validateOnBlur,
-      validateOnChange,
-      children,
-    } = this.props;
+    const {path, format, parse, checkbox, children} = this.props;
 
     return (
       <Consumer>
@@ -206,8 +187,6 @@ class Field extends React.PureComponent<FieldProps> {
               format,
               parse,
               checkbox,
-              validateOnBlur,
-              validateOnChange,
             },
             context,
             {children},
@@ -228,8 +207,6 @@ Field.defaultProps = {
   },
   parse: (v: mixed) => v,
   checkbox: false,
-  validateOnBlur: true,
-  validateOnChange: false,
 };
 
 export default Field;

--- a/src/FieldArray.js
+++ b/src/FieldArray.js
@@ -44,6 +44,7 @@ class FieldArrayWrapper extends React.PureComponent<FieldArrayWrapperProps> {
       value: values,
       pendingValue: pendingValues,
       error: errors,
+      submitError: submitErrors,
       warning: warnings,
       submitting,
 
@@ -67,8 +68,16 @@ class FieldArrayWrapper extends React.PureComponent<FieldArrayWrapperProps> {
       throw new Error(`expected array pendingValue at ${formattedPath}`);
     }
 
+    if (!Array.isArray(warnings)) {
+      throw new Error(`expected array warnings at ${formattedPath}`);
+    }
+
     if (!Array.isArray(errors)) {
       throw new Error(`expected array error at ${formattedPath}`);
+    }
+
+    if (!Array.isArray(submitErrors)) {
+      throw new Error(`expected array submitError at ${formattedPath}`);
     }
 
     const fields = values.map((value, index) => {
@@ -94,6 +103,7 @@ class FieldArrayWrapper extends React.PureComponent<FieldArrayWrapperProps> {
     // potentially with deep equality. Maybe provide a callback to allow the
     // consumer to provide a compare func?
     const hasErrors = hasValue(errors);
+    const hasSubmitErrors = hasValue(submitErrors);
     const hasWarnings = hasValue(warnings);
 
     return children({
@@ -102,6 +112,8 @@ class FieldArrayWrapper extends React.PureComponent<FieldArrayWrapperProps> {
       // "Meta" Props
       hasErrors,
       errors,
+      hasSubmitErrors,
+      submitErrors,
       hasWarnings,
       warnings,
       submitting,
@@ -125,6 +137,8 @@ FieldArrayWrapper.defaultProps = {
   value: [],
   pendingValue: [],
   error: [],
+  warning: [],
+  submitError: [],
 };
 
 class FieldArray extends React.PureComponent<FieldArrayProps> {

--- a/src/FieldArray.js
+++ b/src/FieldArray.js
@@ -38,8 +38,6 @@ class FieldArrayWrapper extends React.PureComponent<FieldArrayWrapperProps> {
       format,
       parse,
       checkbox,
-      validateOnBlur,
-      validateOnChange,
 
       // Field state
       initialValue: initialValues,
@@ -50,7 +48,6 @@ class FieldArrayWrapper extends React.PureComponent<FieldArrayWrapperProps> {
       submitting,
 
       // Context Actions
-      validate,
       submit,
 
       // Render Callbacks
@@ -85,8 +82,6 @@ class FieldArrayWrapper extends React.PureComponent<FieldArrayWrapperProps> {
           format={format}
           parse={parse}
           checkbox={checkbox}
-          validateOnBlur={validateOnBlur}
-          validateOnChange={validateOnChange}
           addField={this.addField.bind(this)}
           removeField={this.removeField.bind(this)}
         >
@@ -115,7 +110,6 @@ class FieldArrayWrapper extends React.PureComponent<FieldArrayWrapperProps> {
       pendingValues,
 
       // Context Actions
-      validate,
       submit,
 
       // FieldArray Actions
@@ -142,8 +136,6 @@ class FieldArray extends React.PureComponent<FieldArrayProps> {
       format,
       parse,
       checkbox,
-      validateOnBlur,
-      validateOnChange,
       renderField,
       children,
       getFieldKey,
@@ -160,8 +152,6 @@ class FieldArray extends React.PureComponent<FieldArrayProps> {
               format,
               parse,
               checkbox,
-              validateOnBlur,
-              validateOnChange,
             },
             context,
             {renderField, children, getFieldKey},

--- a/src/Form.js
+++ b/src/Form.js
@@ -65,9 +65,8 @@ class Form<StateProviderProps>
             submitting={context.submitting}
             submitFailed={context.submitFailed}
             submitSucceeded={context.submitSucceeded}
-            hasErrors={
-              context.errorState !== null && context.submitErrorState !== null
-            }
+            hasErrors={context.errorState !== null}
+            hasSubmitErrors={context.submitErrorState !== null}
             hasWarnings={context.warningState !== null}
           >
             {this.props.children}

--- a/src/Form.js
+++ b/src/Form.js
@@ -32,6 +32,7 @@ class FormWrapper extends React.PureComponent<FormWrapperProps> {
         submitFailed: this.props.submitFailed,
         submitSucceeded: this.props.submitSucceeded,
         hasErrors: this.props.hasErrors,
+        hasSubmitErrors: this.props.hasSubmitErrors,
         hasWarnings: this.props.hasWarnings,
       }),
     );

--- a/src/Form.js
+++ b/src/Form.js
@@ -47,12 +47,9 @@ class Form<StateProviderProps>
   setValue: (path: Path, value: mixed) => void;
   setInitialValue: (path: Path, value: mixed) => void;
   setPendingValue: (path: Path, value: mixed) => void;
-  setWarning: (path: Path, warning: mixed) => void;
-  setError: (path: Path, error: mixed) => void;
   setTouched: (path: Path, touched: boolean) => void;
   setVisited: (path: Path, visited: boolean) => void;
   setFocused: (path: Path, focused: boolean) => void;
-  validate: () => void;
   submit: (event?: Event | SyntheticEvent<>) => void;
 
   render() {

--- a/src/renderWrapper.js
+++ b/src/renderWrapper.js
@@ -28,21 +28,13 @@ const renderWrapper = <P, T>(
     actions,
   } = context;
 
-  let error;
+  const warning =
+    warningState !== null ? get(warningState, parsedPath) : undefined;
 
-  if (submitErrorState !== null) {
-    error = get(submitErrorState, parsedPath);
-  }
+  const error = errorState !== null ? get(errorState, parsedPath) : undefined;
 
-  if (error === undefined && errorState !== null) {
-    error = get(errorState, parsedPath);
-  }
-
-  let warning;
-
-  if (warningState !== null) {
-    warning = get(warningState, parsedPath);
-  }
+  const submitError =
+    submitErrorState !== null ? get(submitErrorState, parsedPath) : undefined;
 
   return (
     <Wrapper
@@ -52,6 +44,7 @@ const renderWrapper = <P, T>(
       pendingValue={get(pendingValueState, parsedPath)}
       warning={warning}
       error={error}
+      submitError={submitError}
       focused={focusedPath === formattedPath}
       touched={!!touchedMap[formattedPath]}
       visited={!!visitedMap[formattedPath]}

--- a/src/types.js
+++ b/src/types.js
@@ -12,12 +12,9 @@ export interface FormActions {
   setValue(path: Path, value: mixed): void;
   setInitialValue(path: Path, value: mixed): void;
   setPendingValue(path: Path, value: mixed): void;
-  setWarning(path: Path, warning: mixed): void;
-  setError(path: Path, error: mixed): void;
   setTouched(path: Path, touched: boolean): void;
   setVisited(path: Path, visited: boolean): void;
   setFocused(path: Path, focused: boolean): void;
-  validate(): void;
   submit(event?: Event | SyntheticEvent<>): void;
 }
 
@@ -34,8 +31,6 @@ export type Context = {|
   submitting: boolean,
   submitFailed: boolean,
   submitSucceeded: boolean,
-  warningStale: boolean,
-  validationStale: boolean,
   actions: FormActions,
 |};
 
@@ -119,7 +114,6 @@ export type FieldRenderProps = {
   acceptPendingValue(): void,
   rejectPendingValue(): void,
   submit(): void,
-  validate(): void,
 
   // FieldArray Actions
   addFieldBefore?: (stateValue: mixed) => void,
@@ -141,7 +135,6 @@ export type FieldArrayRenderProps = {
 
   // Context Actions
   submit(): void,
-  validate(): void,
 
   // FieldArray Props
   addField(value: mixed): void,
@@ -152,8 +145,6 @@ export type FieldConfig = {
   format(stateValue: mixed): mixed,
   parse(fieldValue: mixed, previousStateValue: mixed): mixed,
   checkbox: boolean,
-  validateOnBlur: boolean,
-  validateOnChange: boolean,
 };
 
 type FieldStateProps<T> = {

--- a/src/types.js
+++ b/src/types.js
@@ -55,6 +55,7 @@ type FormWrapperStateProps = {
   submitFailed: boolean,
   submitSucceeded: boolean,
   hasErrors: boolean,
+  hasSubmitErrors: boolean,
   hasWarnings: boolean,
 };
 

--- a/src/types.js
+++ b/src/types.js
@@ -94,6 +94,8 @@ export type FieldRenderProps = {
   // "Meta" Props
   hasError: boolean,
   error: mixed,
+  hasSubmitError: boolean,
+  submitError: mixed,
   hasWarning: boolean,
   warning: mixed,
   focused: boolean,
@@ -152,6 +154,7 @@ type FieldStateProps<T> = {
   value: T,
   pendingValue: T,
   error: T,
+  submitError: T,
   warning: T,
   focused: boolean,
   touched: boolean,

--- a/src/types.js
+++ b/src/types.js
@@ -18,7 +18,7 @@ export interface FormActions {
   submit(event?: Event | SyntheticEvent<>): void;
 }
 
-export type Context = {|
+export type Context = {
   initialValueState: State,
   valueState: State,
   pendingValueState: State,
@@ -32,7 +32,7 @@ export type Context = {|
   submitFailed: boolean,
   submitSucceeded: boolean,
   actions: FormActions,
-|};
+};
 
 export type DefaultStateProviderProps<SubmitResponse> = {
   values: State,

--- a/test/DefaultStateProvider.test.js
+++ b/test/DefaultStateProvider.test.js
@@ -121,8 +121,8 @@ describe('<DefaultStateProvider/>', () => {
       instance = getInstance();
     });
 
-    it('should not modify state if `values` prop has not changed', () => {
-      const nextProps = {...instance.props};
+    it('should not modify state if no relevant props have changed', () => {
+      const nextProps = {...instance.props, foo: 'bar'};
 
       const state = DefaultStateProvider.getDerivedStateFromProps(
         nextProps,
@@ -144,6 +144,46 @@ describe('<DefaultStateProvider/>', () => {
 
       // it should set value state at path
       expect(pendingValueState).toBe(nextProps.values);
+
+      // it should leave remaining state values unchanged
+      expect(shallowIntersect(rest, instance.state)).toBe(true);
+    });
+
+    it('should run `validate` if the prop has changed', () => {
+      const nextProps = {
+        ...instance.props,
+        validate: jest.fn(() => instance.state.errorState),
+      };
+
+      const state = DefaultStateProvider.getDerivedStateFromProps(
+        nextProps,
+        instance.state,
+      );
+
+      // Updating `validate` update the `_props` cache.
+      const {_props, ...rest} = (state: any);
+
+      expect(nextProps.validate.mock.calls).toHaveLength(1);
+
+      // it should leave remaining state values unchanged
+      expect(shallowIntersect(rest, instance.state)).toBe(true);
+    });
+
+    it('should run `warn` if the prop has changed', () => {
+      const nextProps = {
+        ...instance.props,
+        warn: jest.fn(() => instance.state.warningState),
+      };
+
+      const state = DefaultStateProvider.getDerivedStateFromProps(
+        nextProps,
+        instance.state,
+      );
+
+      // Updating `warn` update the `_props` cache.
+      const {_props, ...rest} = (state: any);
+
+      expect(nextProps.warn.mock.calls).toHaveLength(1);
 
       // it should leave remaining state values unchanged
       expect(shallowIntersect(rest, instance.state)).toBe(true);

--- a/test/DefaultStateProvider.test.js
+++ b/test/DefaultStateProvider.test.js
@@ -34,10 +34,8 @@ const getInstance = () => {
     initialValueState: values,
     pendingValueState: values,
     warningState: warnings,
-    warningStale: false,
     errorState: errors,
     submitErrorState: submitErrors,
-    validationStale: false,
   };
 
   return instance;
@@ -94,24 +92,22 @@ describe('<DefaultStateProvider/>', () => {
   });
 
   describe('getInitialState', () => {
-    it('should run validate and warn', () => {
+    it('should run validation', () => {
       const instance = getInstance();
 
       const errors = {foo: 'bar'};
       const warnings = {bar: 'foo'};
 
-      // $ExpectError modify sealed props object
-      instance.props.validate = jest.fn(() => errors);
-      // $ExpectError modify sealed props object
-      instance.props.warn = jest.fn(() => warnings);
+      instance.props = {
+        ...instance.props,
+        validate: jest.fn(() => errors),
+        warn: jest.fn(() => warnings),
+      };
 
       const state = instance.getInitialState();
 
       expect(instance.props.validate.mock.calls).toHaveLength(1);
       expect(instance.props.warn.mock.calls).toHaveLength(1);
-
-      expect(state.validationStale).toBe(false);
-      expect(state.warningStale).toBe(false);
 
       expect(state.errorState).toBe(errors);
       expect(state.warningState).toBe(warnings);
@@ -171,10 +167,8 @@ describe('<DefaultStateProvider/>', () => {
       instance.state = {
         ...instance.state,
         warningState: {},
-        warningStale: false,
         errorState: {},
         submitErrorState: {},
-        validationStale: false,
       };
 
       const previousState = instance.state;
@@ -188,99 +182,77 @@ describe('<DefaultStateProvider/>', () => {
       instance.state = {
         ...instance.state,
         warningState: null,
-        warningStale: false,
         errorState: null,
         submitErrorState: null,
-        validationStale: false,
       };
 
       const previousState = instance.state;
 
       instance.setValue(['foo'], 'bar');
 
-      const {
-        valueState,
-        validationStale,
-        warningStale,
-        ...rest
-      } = instance.state;
+      const {valueState, ...rest} = instance.state;
 
       // it should set value state at path
       expect(valueState).not.toBe(previousState.valueState);
       expect(get(valueState, ['foo'])).toBe('bar');
 
-      // it should reset validation and warning state
-      expect(validationStale).toBe(true);
-      expect(warningStale).toBe(true);
-
       // it should leave remaining state values unchanged
       expect(shallowIntersect(rest, previousState)).toBe(true);
     });
 
-    it('should not unnecessarily update error and warning state', () => {
-      instance.state = {
-        ...instance.state,
-        warningState: {bar: 'warning'},
-        errorState: {bar: 'error'},
-        submitErrorState: {bar: 'error'},
-      };
-
+    it('should run validation', () => {
       const previousState = instance.state;
 
-      instance.setValue(['foo'], 'bar');
+      const errors = {foo: 'bar'};
+      const warnings = {foo: 'foo'};
 
-      const {
-        valueState: _valueState,
-        validationStale: _validationStale,
-        warningStale: _warningStale,
-        ...rest
-      } = instance.state;
-
-      // it should leave remaining state values unchanged
-      expect(shallowIntersect(rest, previousState)).toBe(true);
-    });
-
-    it('should return updated error and warning state', () => {
-      instance.state = {
-        ...instance.state,
-        warningState: {...instance.state.warningState, bar: 'warning'},
-        errorState: {...instance.state.errorState, bar: 'error'},
-        submitErrorState: {...instance.state.submitErrorState, bar: 'error'},
-      };
-
-      const previousState = instance.state;
+      // $ExpectError modify sealed props object
+      instance.props.validate = jest.fn(() => errors);
+      // $ExpectError modify sealed props object
+      instance.props.warn = jest.fn(() => warnings);
 
       instance.setValue(['foo'], 'bar');
 
       const {
         valueState: _,
         errorState,
-        validationStale,
         warningState,
-        warningStale,
         submitErrorState,
         ...rest
       } = instance.state;
 
-      // it should clear error state at path
-      expect(errorState).not.toBe(previousState.errorState);
-      expect(get(errorState, ['foo'])).toBe(undefined);
+      expect(instance.props.validate.mock.calls).toHaveLength(1);
+      expect(instance.props.warn.mock.calls).toHaveLength(1);
 
-      // it should invalidate validation stale state
-      expect(validationStale).not.toBe(previousState.validationStale);
-      expect(validationStale).toBe(true);
+      expect(errorState).toBe(errors);
+      expect(warningState).toBe(warnings);
+      expect(submitErrorState).toBe(null);
 
-      // it should clear warning state at path
-      expect(warningState).not.toBe(previousState.warningState);
-      expect(get(warningState, ['foo'])).toBe(undefined);
+      // it should leave remaining state values unchanged
+      expect(shallowIntersect(rest, previousState)).toBe(true);
+    });
 
-      // it should invalidate warning stale state
-      expect(warningStale).not.toBe(previousState.warningStale);
-      expect(warningStale).toBe(true);
+    it('should convert empty validation state to null', () => {
+      const previousState = instance.state;
 
-      // it should clear submit error state at path
-      expect(submitErrorState).not.toBe(previousState.submitErrorState);
-      expect(get(submitErrorState, ['foo'])).toBe(undefined);
+      // $ExpectError modify sealed props object
+      instance.props.validate = () => ({});
+      // $ExpectError modify sealed props object
+      instance.props.warn = () => [];
+
+      instance.setValue(['foo'], 'bar');
+
+      const {
+        valueState: _,
+        errorState,
+        warningState,
+        submitErrorState,
+        ...rest
+      } = instance.state;
+
+      expect(errorState).toBe(null);
+      expect(warningState).toBe(null);
+      expect(submitErrorState).toBe(null);
 
       // it should leave remaining state values unchanged
       expect(shallowIntersect(rest, previousState)).toBe(true);
@@ -293,8 +265,6 @@ describe('<DefaultStateProvider/>', () => {
 
       const {
         valueState: _valueState,
-        warningStale: _warningStale,
-        validationStale: _validationStale,
         errorState,
         warningState,
         submitErrorState,
@@ -385,108 +355,6 @@ describe('<DefaultStateProvider/>', () => {
       // it should set pending value state at path
       expect(pendingValueState).not.toBe(previousState.pendingValueState);
       expect(get(pendingValueState, ['foo'])).toBe('bar');
-
-      // it should leave remaining state values unchanged
-      expect(shallowIntersect(rest, previousState)).toBe(true);
-    });
-  });
-
-  describe('static setWarning', () => {
-    let instance;
-
-    beforeEach(() => {
-      instance = getInstance();
-    });
-
-    it('should throw if the path is empty', () => {
-      expect(() => {
-        instance.setWarning([], {});
-      }).toThrow(emptyPathArrayError());
-    });
-
-    it('should not modify state if change is idempotent', () => {
-      instance.state = {
-        ...instance.state,
-        warningState: null,
-      };
-
-      const previousState = instance.state;
-
-      instance.setWarning(['foo'], undefined);
-
-      expect(instance.state).toBe(previousState);
-    });
-
-    it('should return updated warning state', () => {
-      const previousState = instance.state;
-
-      instance.setWarning(['foo'], 'bar');
-
-      const {warningState, warningStale, ...rest} = instance.state;
-
-      // it should set warning state at path
-      expect(warningState).not.toBe(previousState.warningState);
-      expect(get(warningState, ['foo'])).toBe('bar');
-
-      // it should invalidate warning stale state
-      expect(warningStale).not.toBe(previousState.warningStale);
-      expect(warningStale).toBe(true);
-
-      // it should leave remaining state values unchanged
-      expect(shallowIntersect(rest, previousState)).toBe(true);
-    });
-  });
-
-  describe('static setError', () => {
-    let instance;
-
-    beforeEach(() => {
-      instance = getInstance();
-    });
-
-    it('should throw if the path is empty', () => {
-      expect(() => {
-        instance.setError([], {});
-      }).toThrow(emptyPathArrayError());
-    });
-
-    it('should not modify state if change is idempotent', () => {
-      instance.state = {
-        ...instance.state,
-        errorState: null,
-        submitErrorState: null,
-      };
-
-      const previousState = instance.state;
-
-      instance.setError(['foo'], undefined);
-
-      expect(instance.state).toBe(previousState);
-    });
-
-    it('should return updated error state', () => {
-      const previousState = instance.state;
-
-      instance.setError(['foo'], 'bar');
-
-      const {
-        errorState,
-        validationStale,
-        submitErrorState,
-        ...rest
-      } = instance.state;
-
-      // it should set error state at path
-      expect(errorState).not.toBe(previousState.errorState);
-      expect(get(errorState, ['foo'])).toBe('bar');
-
-      // it should clear submit error state at path
-      expect(submitErrorState).not.toBe(previousState.submitErrorState);
-      expect(submitErrorState).toBe(null);
-
-      // it should invalidate error stale state
-      expect(validationStale).not.toBe(previousState.validationStale);
-      expect(validationStale).toBe(true);
 
       // it should leave remaining state values unchanged
       expect(shallowIntersect(rest, previousState)).toBe(true);
@@ -638,90 +506,6 @@ describe('<DefaultStateProvider/>', () => {
     });
   });
 
-  describe('validate', () => {
-    let instance;
-
-    beforeEach(() => {
-      instance = getInstance();
-    });
-
-    it('should not modify state if cached result is not stale', () => {
-      instance.state = {
-        ...instance.state,
-        warningStale: false,
-        validationStale: false,
-      };
-
-      const previousState = instance.state;
-
-      instance.validate();
-
-      expect(instance.state).toBe(previousState);
-    });
-
-    it('should call validate and warn and update state with results', () => {
-      instance.state = {
-        ...instance.state,
-        warningStale: true,
-        validationStale: true,
-      };
-
-      const validateResult = {foo: 'bar'};
-      const warnResult = {foo: 'bar'};
-
-      const validate = jest.fn(() => validateResult);
-      const warn = jest.fn(() => warnResult);
-
-      instance.props = {...instance.props, validate, warn};
-
-      const previousState = instance.state;
-
-      instance.validate();
-
-      expect(validate.mock.calls).toHaveLength(1);
-      expect(validate.mock.calls[0][0]).toBe(instance.state.valueState);
-
-      expect(warn.mock.calls).toHaveLength(1);
-      expect(warn.mock.calls[0][0]).toBe(instance.state.valueState);
-
-      const {
-        errorState,
-        validationStale,
-        warningState,
-        warningStale,
-        ...rest
-      } = instance.state;
-
-      expect(errorState).toBe(validateResult);
-      expect(validationStale).toBe(false);
-
-      expect(warningState).toBe(warnResult);
-      expect(warningStale).toBe(false);
-
-      // it should leave remaining state values unchanged
-      expect(shallowIntersect(rest, previousState)).toBe(true);
-    });
-
-    it('should handle falsy callback results', () => {
-      instance.state = {
-        ...instance.state,
-        warningStale: true,
-        validationStale: true,
-      };
-
-      instance.props = {
-        ...instance.props,
-        validate() {},
-        warn() {},
-      };
-
-      instance.validate();
-
-      expect(instance.state.errorState).toBe(null);
-      expect(instance.state.warningState).toBe(null);
-    });
-  });
-
   describe('submit', () => {
     let instance;
     let promise;
@@ -765,48 +549,10 @@ describe('<DefaultStateProvider/>', () => {
       );
     });
 
-    it('should run validation if validation state is stale', async () => {
-      instance.state = {
-        ...instance.state,
-        validationStale: true,
-      };
-
-      const errors = {foo: 'bar'};
-
-      instance.props = {
-        ...instance.props,
-        validate: jest.fn(() => errors),
-      };
-
-      instance.submit();
-
-      await expect(promise).rejects.toThrowError();
-
-      expect(instance.props.validate.mock.calls).toHaveLength(1);
-
-      const {
-        submitting,
-        submitSucceeded,
-        submitFailed,
-        submitErrorState,
-        ...rest
-      } = instance.state;
-
-      expect(submitting).toBe(false);
-      expect(submitSucceeded).toBe(false);
-      expect(submitFailed).toBe(true);
-      expect(submitErrorState).toBe(errors);
-
-      // it should leave remaining state values unchanged
-      expect(shallowIntersect(rest, instance.state)).toBe(true);
-    });
-
     it('should reject if error state is not null', async () => {
       instance.state = {
         ...instance.state,
         errorState: {foo: 'bar'},
-        validationStale: false,
-        warningStale: false,
       };
 
       instance.submit();
@@ -841,6 +587,50 @@ describe('<DefaultStateProvider/>', () => {
       expect(submitting).toBe(false);
       expect(submitSucceeded).toBe(true);
       expect(submitFailed).toBe(false);
+      expect(submitErrorState).toBe(null);
+
+      // it should leave remaining state values unchanged
+      expect(shallowIntersect(rest, instance.state)).toBe(true);
+    });
+
+    it('should store submit validation errors', async () => {
+      const errors = {foo: 'submitError'};
+
+      const error = new SubmitValidationError(errors);
+
+      instance.props = {
+        ...instance.props,
+        onSubmit: () => Promise.reject(error),
+      };
+
+      instance.submit();
+
+      await expect(promise).rejects.toEqual(error);
+
+      const {submitErrorState, ...rest} = instance.state;
+
+      expect(submitErrorState).toBe(errors);
+
+      // it should leave remaining state values unchanged
+      expect(shallowIntersect(rest, instance.state)).toBe(true);
+    });
+
+    it('should store convert empty submit validation to null', async () => {
+      const errors = {};
+
+      const error = new SubmitValidationError(errors);
+
+      instance.props = {
+        ...instance.props,
+        onSubmit: () => Promise.reject(error),
+      };
+
+      instance.submit();
+
+      await expect(promise).rejects.toEqual(error);
+
+      const {submitErrorState, ...rest} = instance.state;
+
       expect(submitErrorState).toBe(null);
 
       // it should leave remaining state values unchanged

--- a/test/DefaultStateProvider.test.js
+++ b/test/DefaultStateProvider.test.js
@@ -93,6 +93,31 @@ describe('<DefaultStateProvider/>', () => {
     });
   });
 
+  describe('getInitialState', () => {
+    it('should run validate and warn', () => {
+      const instance = getInstance();
+
+      const errors = {foo: 'bar'};
+      const warnings = {bar: 'foo'};
+
+      // $ExpectError modify sealed props object
+      instance.props.validate = jest.fn(() => errors);
+      // $ExpectError modify sealed props object
+      instance.props.warn = jest.fn(() => warnings);
+
+      const state = instance.getInitialState();
+
+      expect(instance.props.validate.mock.calls).toHaveLength(1);
+      expect(instance.props.warn.mock.calls).toHaveLength(1);
+
+      expect(state.validationStale).toBe(false);
+      expect(state.warningStale).toBe(false);
+
+      expect(state.errorState).toBe(errors);
+      expect(state.warningState).toBe(warnings);
+    });
+  });
+
   describe('static getDerivedStateFromProps', () => {
     let instance;
 


### PR DESCRIPTION
Simplify the validation system, removing the `validateOnChange` and `validateOnBlur` options. Validation now runs on every value change.

The benefit is that the validation state will _always_ be current for the given value state. This also greatly simplifies the internal validation state management, doing away with the `stale` flags entirely.

Assuming that the provided validation callback is not expensive, this should not negatively affect performance.

closes #2