### PR TITLE
Add tag filters to release jobs in circle workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,15 +133,15 @@ workflows:
       - lint:
           filters:
             tags:
-              only: /^v.*/
+              only: /^v\d+\.\d+\.\d+/
       - types:
           filters:
             tags:
-              only: /^v.*/
+              only: /^v\d+\.\d+\.\d+/
       - spec:
           filters:
             tags:
-              only: /^v.*/
+              only: /^v\d+\.\d+\.\d+/
 
       # build non-release npm package on any branch and not on tags
       - build:
@@ -162,7 +162,7 @@ workflows:
       - build_release:
           filters:
             tags:
-              only: /^v.*/
+              only: /^v\d+\.\d+\.\d+/
             branches:
               ignore: /.*/
           requires:
@@ -173,10 +173,16 @@ workflows:
       # hold workflow pending user approval
       - approve_release:
           type: approval
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+/
           requires:
             - build_release
 
       # publish latest tagged npm package when approved
       - publish_release:
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+/
           requires:
             - approve_release


### PR DESCRIPTION
CircleCI will not run jobs for a tag push unless a tag filter is specified.

The previous config worked up to the `build_release` for a pushed tag, but the following jobs did not run.

I'm also trying to troubleshoot the tag filter regex so that only semver tags trigger builds.