### PR TITLE
Fix circle workflow tag filter regex

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,15 +133,15 @@ workflows:
       - lint:
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+/
+              only: /^v\d+\.\d+\.\d+(-.+)?$/
       - types:
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+/
+              only: /^v\d+\.\d+\.\d+(-.+)?$/
       - spec:
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+/
+              only: /^v\d+\.\d+\.\d+(-.+)?$/
 
       # build non-release npm package on any branch and not on tags
       - build:
@@ -162,7 +162,7 @@ workflows:
       - build_release:
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+/
+              only: /^v\d+\.\d+\.\d+(-.+)?$/
             branches:
               ignore: /.*/
           requires:
@@ -175,7 +175,7 @@ workflows:
           type: approval
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+/
+              only: /^v\d+\.\d+\.\d+(-.+)?$/
           requires:
             - build_release
 
@@ -183,6 +183,6 @@ workflows:
       - publish_release:
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+/
+              only: /^v\d+\.\d+\.\d+(-.+)?$/
           requires:
             - approve_release


### PR DESCRIPTION
I'm assuming that circle implicitly includes an end token if one isn't included in the regex.

This fixes the problem of the release jobs not running on git tags of semver strings that include tags or build meta.