### PR TITLE
Add jest eslint plugin to forbid .only and .skip

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,6 +4,7 @@ parserOptions:
 plugins:
   - react
   - prettier
+  - jest
   - '@typescript-eslint'
 extends:
   - eslint:recommended
@@ -28,6 +29,7 @@ rules:
     - allowTypedFunctionExpressions: true
       allowExpressions: true
   react/prop-types: off
+
 overrides:
   - files: "*.test.tsx"
     env:
@@ -35,6 +37,15 @@ overrides:
       node: true
     rules:
       '@typescript-eslint/explicit-function-return-type': off
+      jest/no-disabled-tests: error
+      jest/no-focused-tests: error
+      jest/no-identical-title: error
+      jest/prefer-to-have-length: error
+      jest/valid-expect: error
+      jest/prefer-to-be-null: error
+      jest/prefer-to-be-undefined: error
+      jest/prefer-to-contain: error
+
   - files: "*.stories.tsx"
     env:
       node: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,14 +146,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/runtime": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
-      "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
-      "requires": {
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
     "@babel/template": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
@@ -550,6 +542,7 @@
       "version": "24.8.0",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
       "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
+      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
@@ -559,7 +552,8 @@
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
-      "integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q=="
+      "integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
+      "dev": true
     },
     "@testing-library/dom": {
       "version": "6.2.0",
@@ -670,12 +664,14 @@
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg=="
+      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
+      "dev": true
     },
     "@types/istanbul-lib-report": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
       "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -684,6 +680,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
       "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
@@ -778,7 +775,8 @@
     "@types/yargs": {
       "version": "12.0.12",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.12.tgz",
-      "integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw=="
+      "integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==",
+      "dev": true
     },
     "@types/yargs-parser": {
       "version": "13.1.0",
@@ -895,12 +893,14 @@
     "ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1416,6 +1416,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1423,7 +1424,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -1676,17 +1678,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "dom-testing-library": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/dom-testing-library/-/dom-testing-library-4.1.0.tgz",
-      "integrity": "sha512-654GHd0oPC31S+ll1bJH9NUOBRzcHcrf23/XzJh41o6g67uGUpF9tn23qmbcwjNauoRqKQfAdHCDwr/Ez/Ot7A==",
-      "requires": {
-        "@babel/runtime": "^7.4.3",
-        "@sheerun/mutationobserver-shim": "^0.3.2",
-        "pretty-format": "^24.7.0",
-        "wait-for-expect": "^1.1.1"
-      }
-    },
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -1872,6 +1863,15 @@
             "ansi-regex": "^3.0.0"
           }
         }
+      }
+    },
+    "eslint-plugin-jest": {
+      "version": "22.17.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.17.0.tgz",
+      "integrity": "sha512-WT4DP4RoGBhIQjv+5D0FM20fAdAUstfYAf/mkufLNTojsfgzc5/IYW22cIg/Q4QBavAZsROQlqppiWDpFZDS8Q==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^1.13.0"
       }
     },
     "eslint-plugin-prettier": {
@@ -5565,6 +5565,7 @@
       "version": "24.8.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
       "integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
+      "dev": true,
       "requires": {
         "@jest/types": "^24.8.0",
         "ansi-regex": "^4.0.0",
@@ -5659,16 +5660,8 @@
     "react-is": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
-    },
-    "react-testing-library": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/react-testing-library/-/react-testing-library-7.0.1.tgz",
-      "integrity": "sha512-doQkM3/xPcIm22x9jgTkGxU8xqXg4iWvM1WwbbQ7CI5/EMk3DhloYBwMyk+Ywtta3dIAIh9sC7llXoKovf3L+w==",
-      "requires": {
-        "@babel/runtime": "^7.4.3",
-        "dom-testing-library": "^4.1.0"
-      }
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+      "dev": true
     },
     "read-pkg": {
       "version": "3.0.0",
@@ -5728,7 +5721,8 @@
     "regenerator-runtime": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
+      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -7087,11 +7081,6 @@
       "requires": {
         "browser-process-hrtime": "^0.1.2"
       }
-    },
-    "wait-for-expect": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.2.0.tgz",
-      "integrity": "sha512-EJhKpA+5UHixduMBEGhTFuLuVgQBKWxkFbefOdj2bbk2/OpA5Opsc4aUTGmF+qJ+v3kTGxDRNYwKaT4j6g5n8Q=="
     },
     "walker": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@typescript-eslint/eslint-plugin": "1.13.0",
     "@typescript-eslint/parser": "1.13.0",
     "eslint": "5.16.0",
+    "eslint-plugin-jest": "^22.17.0",
     "eslint-plugin-prettier": "3.1.0",
     "eslint-plugin-react": "7.14.3",
     "jest": "24.9.0",

--- a/src/test/util.test.tsx
+++ b/src/test/util.test.tsx
@@ -218,7 +218,7 @@ describe('utils', () => {
     it('should set a value at the correct path', () => {
       const state = {foo: {bar: [1, 2, 3, {foo: 'bar'}]}};
 
-      expect(set(state, [], null)).toEqual(null);
+      expect(set(state, [], null)).toBeNull();
 
       expect(set(state, ['foo'], null)).toEqual({...state, foo: null});
 
@@ -319,7 +319,7 @@ describe('utils', () => {
         },
       });
 
-      expect(updater.mock.calls.length).toBe(1);
+      expect(updater).toHaveBeenCalledTimes(1);
       expect((updater as any).mock.calls[0][0]).toBe('bar');
     });
   });
@@ -332,7 +332,7 @@ describe('utils', () => {
 
       expect(get(state, ['foo'])).toBe(state.foo);
 
-      expect(get(state, ['foo', 'foo', 'foo', 'foo'])).toEqual(undefined);
+      expect(get(state, ['foo', 'foo', 'foo', 'foo'])).toBeUndefined();
 
       expect(get(state, ['foo', 'bar', 0])).toEqual(state.foo.bar[0]);
 
@@ -425,13 +425,13 @@ describe('utils', () => {
       mergedHandlerA(event);
       mergedHandlerB(event);
 
-      expect(handlerA.mock.calls.length).toEqual(1);
+      expect(handlerA).toHaveBeenCalledTimes(1);
       expect(handlerA.mock.calls[0][0]).toBe(event);
 
-      expect(handlerB.mock.calls.length).toEqual(1);
+      expect(handlerB).toHaveBeenCalledTimes(1);
       expect(handlerB.mock.calls[0][0]).toBe(event);
 
-      expect(handlerC.mock.calls.length).toEqual(1);
+      expect(handlerC).toHaveBeenCalledTimes(1);
       expect(handlerC.mock.calls[0][0]).toBe(event);
     });
 
@@ -447,16 +447,16 @@ describe('utils', () => {
 
       mergedHandler(event);
 
-      expect(handlerA.mock.calls.length).toEqual(1);
+      expect(handlerA).toHaveBeenCalledTimes(1);
       expect(handlerA.mock.calls[0][0]).toBe(event);
 
-      expect(handlerB.mock.calls.length).toEqual(0);
+      expect(handlerB).toHaveBeenCalledTimes(0);
     });
   });
 
   describe('parseEvent', () => {
     it('should return non Event instances', () => {
-      expect(parseEvent(null)).toEqual(null);
+      expect(parseEvent(null)).toBeNull();
     });
 
     it('should return the value of a plain event target', () => {


### PR DESCRIPTION
The `no-focused-tests` and `no-disabled-tests` rules forbid using `.skip` and `.only` and helps inadvertently disabling which tests are run.