### PR TITLE
Fix touched and visited values for deep paths

### DIFF
--- a/src/useField.tsx
+++ b/src/useField.tsx
@@ -54,8 +54,8 @@ const updateFieldState = <FV, FE, FW>(
   let nextState = state;
 
   const focused = formState.focusedPath === formattedPath;
-  const visited = !!get(formState.visitedMap, parsedPath);
-  const touched = !!get(formState.touchedMap, parsedPath);
+  const visited = !!get(formState.visitedMap, [formattedPath]);
+  const touched = !!get(formState.touchedMap, [formattedPath]);
 
   const value = get(formState.values, parsedPath) as FV;
   const pendingValue = get(formState.pendingValues, parsedPath) as FV;

--- a/src/useFieldStatus.tsx
+++ b/src/useFieldStatus.tsx
@@ -28,8 +28,8 @@ export const updateFieldStatus = <FV extends any>(
   let nextState = state;
 
   const focused = formState.focusedPath === formattedPath;
-  const visited = !!get(formState.visitedMap, parsedPath);
-  const touched = !!get(formState.touchedMap, parsedPath);
+  const visited = !!get(formState.visitedMap, [formattedPath]);
+  const touched = !!get(formState.touchedMap, [formattedPath]);
 
   const value = get(formState.values, parsedPath) as FV;
   const pendingValue = get(formState.pendingValues, parsedPath) as FV;


### PR DESCRIPTION
This change fixes a bug where `touched` and `visited` values are not correctly returned when using a deep path to a field.

The `touched` and `visited` state is stored as a flat map whose keys are concatenated path strings i.e. `field.path` not paths arrays i.e `['field', 'path']`.

